### PR TITLE
feat(playground): add drag-to-resize code panel

### DIFF
--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -284,7 +284,6 @@ function readStoredPanelWidth(): number | null {
   return Number.isFinite(stored) && stored > 0 ? stored : null
 }
 
-/** drag-to-resize for the code panel, persisted across reloads */
 function useResizablePanel() {
   const [width, setWidth] = useState(() => readStoredPanelWidth() ?? Math.round(window.innerWidth * 0.42))
   const dragState = useRef<{ startX: number; startWidth: number } | null>(null)

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -201,6 +201,7 @@ function Workspace({ code, theme, readOnly }: { code: string; theme: string; rea
   const [tool, setToolState] = useState<Tool>('select')
   const [status, setStatus] = useState<string | null>(null)
   const [pane, setPane] = useState<'codemirror' | 'monaco'>('codemirror')
+  const panelWidth = useResizablePanel()
 
   // theme changes flow through the MermaidCanvas mermaidConfig prop
 
@@ -245,7 +246,8 @@ function Workspace({ code, theme, readOnly }: { code: string; theme: string; rea
           style={{ height: '100%' }}
         />
       </main>
-      <section className="codepanel">
+      <div className="resizer" onMouseDown={panelWidth.startDrag} />
+      <section className="codepanel" style={{ width: panelWidth.width, flexBasis: panelWidth.width }}>
         <div className="panel-title">
           <span className="panel-title-left">
             Mermaid source
@@ -271,6 +273,54 @@ function Workspace({ code, theme, readOnly }: { code: string; theme: string; rea
       </section>
     </>
   )
+}
+
+const PANEL_WIDTH_KEY = 'visimer:playground:panelWidth'
+const PANEL_MIN_WIDTH = 340
+const PANEL_MAX_RATIO = 0.7
+
+function readStoredPanelWidth(): number | null {
+  const stored = Number(localStorage.getItem(PANEL_WIDTH_KEY))
+  return Number.isFinite(stored) && stored > 0 ? stored : null
+}
+
+/** drag-to-resize for the code panel, persisted across reloads */
+function useResizablePanel() {
+  const [width, setWidth] = useState(() => readStoredPanelWidth() ?? Math.round(window.innerWidth * 0.42))
+  const dragState = useRef<{ startX: number; startWidth: number } | null>(null)
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!dragState.current) return
+      const { startX, startWidth } = dragState.current
+      const max = window.innerWidth * PANEL_MAX_RATIO
+      const next = Math.min(max, Math.max(PANEL_MIN_WIDTH, startWidth - (e.clientX - startX)))
+      setWidth(next)
+    }
+    const onUp = () => {
+      if (!dragState.current) return
+      dragState.current = null
+      document.body.classList.remove('resizing')
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(PANEL_WIDTH_KEY, String(width))
+  }, [width])
+
+  const startDrag = (e: React.MouseEvent) => {
+    e.preventDefault()
+    dragState.current = { startX: e.clientX, startWidth: width }
+    document.body.classList.add('resizing')
+  }
+
+  return { width, startDrag }
 }
 
 /** re-render on document changes */

--- a/apps/playground/src/App.tsx
+++ b/apps/playground/src/App.tsx
@@ -11,6 +11,7 @@ import type { MermaidCanvasView, Tool } from '@visimer/dom'
 import { MermaidCanvas, useMermaidEditor } from '@visimer/react'
 import { MermaidCodeMirror } from '@visimer/codemirror'
 import { MonacoPane } from './MonacoPane'
+import { useResizablePanel } from './hooks/useResizablePanel'
 import { SAMPLES } from '../../js-playground/src/samples'
 
 let zenumlReady: Promise<boolean> | null = null
@@ -273,53 +274,6 @@ function Workspace({ code, theme, readOnly }: { code: string; theme: string; rea
       </section>
     </>
   )
-}
-
-const PANEL_WIDTH_KEY = 'visimer:playground:panelWidth'
-const PANEL_MIN_WIDTH = 340
-const PANEL_MAX_RATIO = 0.7
-
-function readStoredPanelWidth(): number | null {
-  const stored = Number(localStorage.getItem(PANEL_WIDTH_KEY))
-  return Number.isFinite(stored) && stored > 0 ? stored : null
-}
-
-function useResizablePanel() {
-  const [width, setWidth] = useState(() => readStoredPanelWidth() ?? Math.round(window.innerWidth * 0.42))
-  const dragState = useRef<{ startX: number; startWidth: number } | null>(null)
-
-  useEffect(() => {
-    const onMove = (e: MouseEvent) => {
-      if (!dragState.current) return
-      const { startX, startWidth } = dragState.current
-      const max = window.innerWidth * PANEL_MAX_RATIO
-      const next = Math.min(max, Math.max(PANEL_MIN_WIDTH, startWidth - (e.clientX - startX)))
-      setWidth(next)
-    }
-    const onUp = () => {
-      if (!dragState.current) return
-      dragState.current = null
-      document.body.classList.remove('resizing')
-    }
-    window.addEventListener('mousemove', onMove)
-    window.addEventListener('mouseup', onUp)
-    return () => {
-      window.removeEventListener('mousemove', onMove)
-      window.removeEventListener('mouseup', onUp)
-    }
-  }, [])
-
-  useEffect(() => {
-    localStorage.setItem(PANEL_WIDTH_KEY, String(width))
-  }, [width])
-
-  const startDrag = (e: React.MouseEvent) => {
-    e.preventDefault()
-    dragState.current = { startX: e.clientX, startWidth: width }
-    document.body.classList.add('resizing')
-  }
-
-  return { width, startDrag }
 }
 
 /** re-render on document changes */

--- a/apps/playground/src/app.css
+++ b/apps/playground/src/app.css
@@ -139,12 +139,12 @@ body.resizing * { user-select: none; }
   display: flex; flex-direction: column;
 }
 .panel-title {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 8px 14px; border-bottom: 1px solid var(--border);
+  display: flex; align-items: center; justify-content: space-between; flex-wrap: wrap;
+  gap: 6px 12px; padding: 8px 14px; border-bottom: 1px solid var(--border);
   font-size: 11px; font-weight: 500; color: var(--dimmer);
   text-transform: uppercase; letter-spacing: 0.06em;
 }
-.panel-title-left { display: flex; align-items: center; gap: 10px; }
+.panel-title-left { display: flex; align-items: center; gap: 10px; min-width: 0; flex-wrap: wrap; }
 .seg {
   display: inline-flex; padding: 2px; gap: 2px;
   border: 1px solid var(--border); border-radius: 6px; background: var(--panel);
@@ -159,6 +159,7 @@ body.resizing * { user-select: none; }
 .badge {
   font-size: 11px; text-transform: none; letter-spacing: 0; font-weight: 500;
   padding: 2px 8px; border-radius: 99px; border: 1px solid var(--border-strong); color: var(--dim);
+  flex: 0 0 auto; white-space: nowrap;
 }
 .badge.edit { color: var(--green); border-color: color-mix(in srgb, var(--green) 40%, transparent); }
 

--- a/apps/playground/src/app.css
+++ b/apps/playground/src/app.css
@@ -120,10 +120,23 @@ select { appearance: none; padding-right: 26px; background-image: url("data:imag
 .canvas svg span.edgeLabel:not(:empty) { border-radius: 4px; padding: 1px 6px; margin: -1px -6px; display: inline-block; }
 .canvas svg span.edgeLabel:empty { background: transparent !important; }
 
+/* resizer */
+.resizer {
+  flex: 0 0 auto; width: 5px; cursor: col-resize; background: transparent;
+  position: relative;
+}
+.resizer::after {
+  content: ''; position: absolute; top: 0; bottom: 0; left: 2px; width: 1px;
+  background: var(--border);
+}
+.resizer:hover::after, body.resizing .resizer::after { background: var(--blue); width: 2px; left: 1.5px; }
+body.resizing { cursor: col-resize; user-select: none; }
+body.resizing * { user-select: none; }
+
 /* code panel */
 .codepanel {
-  flex: 1 1 44%; min-width: 340px; max-width: 46%;
-  display: flex; flex-direction: column; border-left: 1px solid var(--border);
+  flex: 0 0 auto; min-width: 340px; max-width: 70%;
+  display: flex; flex-direction: column;
 }
 .panel-title {
   display: flex; align-items: center; justify-content: space-between;

--- a/apps/playground/src/hooks/useResizablePanel.ts
+++ b/apps/playground/src/hooks/useResizablePanel.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from 'react'
+
+const PANEL_WIDTH_KEY = 'visimer:playground:panelWidth'
+const PANEL_MIN_WIDTH = 340
+const PANEL_MAX_RATIO = 0.7
+
+function readStoredPanelWidth(): number | null {
+  const stored = Number(localStorage.getItem(PANEL_WIDTH_KEY))
+  return Number.isFinite(stored) && stored > 0 ? stored : null
+}
+
+/** drag-to-resize for the code panel, persisted across reloads */
+export function useResizablePanel() {
+  const [width, setWidth] = useState(() => readStoredPanelWidth() ?? Math.round(window.innerWidth * 0.42))
+  const dragState = useRef<{ startX: number; startWidth: number } | null>(null)
+
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!dragState.current) return
+      const { startX, startWidth } = dragState.current
+      const max = window.innerWidth * PANEL_MAX_RATIO
+      const next = Math.min(max, Math.max(PANEL_MIN_WIDTH, startWidth - (e.clientX - startX)))
+      setWidth(next)
+    }
+    const onUp = () => {
+      if (!dragState.current) return
+      dragState.current = null
+      document.body.classList.remove('resizing')
+    }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(PANEL_WIDTH_KEY, String(width))
+  }, [width])
+
+  const startDrag = (e: React.MouseEvent) => {
+    e.preventDefault()
+    dragState.current = { startX: e.clientX, startWidth: width }
+    document.body.classList.add('resizing')
+  }
+
+  return { width, startDrag }
+}


### PR DESCRIPTION
## Summary
- Adds a draggable divider between the canvas and the Mermaid source panel in the playground app, so the code panel width can be resized by dragging. Width is clamped (340px–70% of viewport) and persisted to localStorage across reloads.
- Fixes the diagram-type badge in the panel title so it wraps cleanly instead of overlapping/squeezing at narrow panel widths.

## Motivation
I'd like to start contributing to Visimer's development — this is my first PR to get familiar with the codebase and playground app. Happy to take feedback on approach/naming and iterate. Have good understanding what features should be next.
